### PR TITLE
chore(readme): add datasets detail in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install -r requirements.txt
 - About 50 audio-text pairs will suffice and 100-600 epochs could have quite good performance, but more data may be better. 
 - Resample all audio to 22050Hz, 16-bit, mono wav files.
 - Audio files should be >=1s and <=10s.
+- Audio files scale should be in linear
 ```
 path/to/XXX.wav|speaker id|transcript
 ```


### PR DESCRIPTION
For now, the scale isn't specified. I'm using audacity to export the audio file, by default the scale it uses is `Mel` and it turns out the tensor padding wont work. When I try to check the tensor shape, it became like this 
![image](https://user-images.githubusercontent.com/48182208/229851279-ff5db813-2245-4bf4-bf5c-4e330a6f86ff.png)



Meanwhile the provided data from repository shape's like this
![image](https://user-images.githubusercontent.com/48182208/229851744-44d3ef67-1da0-4bab-82ca-64e0acb97033.png)



For this case, I use Audacity to export the `.wav` file, after I turn on the multi-view settings on the audio file and change the scale's spectrogram settings for that audio to `Linear` I am able to achieve similar shape like the provided audio file from repository.
![image](https://user-images.githubusercontent.com/48182208/229852497-f9de4820-f1d3-4cb8-83ff-8220239244ab.png)
